### PR TITLE
Continues fetching content if the first page of auto-loaded content doesn't fill the window

### DIFF
--- a/jquery-ui.scrollAppend.js
+++ b/jquery-ui.scrollAppend.js
@@ -298,6 +298,8 @@
 				if(self.options.callback) self.options.callback.apply();
 
 				self.loading = false;
+
+				self.checkAppend();
 			}
 		});
 	},


### PR DESCRIPTION
Right now, because scrollAppend.js only checks whether it needs to get more stuff on scroll and once on page load, if the first page of content doesn't fill the screen, scrollAppend.js doesn't grab more because no scroll events tell it to check whether it needs to.
